### PR TITLE
package: fix version in remove action

### DIFF
--- a/chef/lib/chef/provider/package/zypper.rb
+++ b/chef/lib/chef/provider/package/zypper.rb
@@ -103,6 +103,7 @@ class Chef
         end
 
         def remove_package(name, version)
+          version = version.nil? || version.empty? ? @current_resource.version : version
           zypper_package("remove", name, version)
         end
       


### PR DESCRIPTION
As the class calling the Zypper provider uses @new_resource to
obtain the version, it could lead to the version number being
empty thus crashing the remove resource.

Instead do a bit more of safe checking for a valid version and
fall back to use the @current_resource version if the package
provider is passing an empty or nil version number